### PR TITLE
Add optional KYB pass-through example to onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,45 @@ This section assumes that:
    4. The backend will [return the URL to the frontend](https://github.com/tremendous-rewards/tremendous-for-platforms-sample-app/blob/acf796c145a8eec2f3f538735f4e674cc9b17bba/controllers/organizations_controller.rb#L81), which will [redirect the user to the session URL](https://github.com/tremendous-rewards/tremendous-for-platforms-sample-app/blob/acf796c145a8eec2f3f538735f4e674cc9b17bba/views/organizations/show.erb#L70-L90)
    ![tremendous-flow](docs/images/tremendous-flow.png)
 
+### Pre-filling KYB info (optional)
+
+If your platform already collects KYB (Know Your Business) information from your end
+clients, you can forward it to Tremendous so the end client doesn't have to re-type it.
+When provided, Tremendous pre-fills the onboarding form with this data; the end client
+still reviews every field, can edit anything, and submits the form as usual.
+
+To pass it through, include an optional `kyb` object in the body of the
+[`POST /connected_organizations`](https://developers.tremendous.com/reference/create-connected-organization)
+call. This sample app collects these fields in the optional "KYB pass-through" section of
+the "New Organization" form and sends them when you click "Set up on Tremendous"
+(see [`TremendousApiService.create_connected_organization`](services/tremendous_api_service.rb)).
+
+The supported fields are:
+
+```jsonc
+{
+  "client_id": "<your-oauth-client-id>",
+  "kyb": {
+    "company_name": "Acme Inc",
+    "doing_business_as": "Acme",
+    "company_structure": "llc",
+    "company_registration_number": "12-3456789",
+    "country_code": "US",
+    "website_url": "https://acme.example",
+    "address": {
+      "line1": "1 Main St",
+      "city": "Austin",
+      "state": "TX",
+      "zip": "78701"
+    }
+  }
+}
+```
+
+Every field is optional. This sample app only includes the fields you actually fill in and
+omits the `kyb` object entirely when none are provided, so the call works unchanged when you
+have no KYB data to forward.
+
 ### Listening for webhooks
 
 This sample app shows how to listen for webhooks from Tremendous. These are handled by the [WebhooksController](https://github.com/tremendous-rewards/tremendous-for-platforms-sample-app/blob/main/controllers/webhooks_controller.rb) and are expected to be received in the `/webhooks` path.

--- a/controllers/organizations_controller.rb
+++ b/controllers/organizations_controller.rb
@@ -38,9 +38,13 @@ class OrganizationsController < BaseController
     @organization = Organization.find(params[:id])
 
     begin
-      # Tremendous API call to create the connected organization
+      # Tremendous API call to create the connected organization, optionally
+      # passing through any KYB info the platform already collected so the end
+      # client's onboarding form is pre-filled.
       if @organization.tremendous_connected_organization_id.blank?
-        response = TremendousApiService.create_connected_organization
+        response = TremendousApiService.create_connected_organization(
+          kyb: @organization.prefilled_kyb_details
+        )
 
         payload = response.fetch("connected_organization")
         @organization.update!(tremendous_connected_organization_id: payload.fetch("id"))

--- a/db/migrate/20260605000000_add_kyb_fields_to_organizations.rb
+++ b/db/migrate/20260605000000_add_kyb_fields_to_organizations.rb
@@ -1,0 +1,17 @@
+class AddKybFieldsToOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    # Optional KYB pass-through fields. When provided, these are sent to
+    # Tremendous as the `kyb` object on POST /connected_organizations, which
+    # pre-fills the end client's onboarding form. All fields are optional.
+    add_column :organizations, :kyb_company_name, :string
+    add_column :organizations, :kyb_doing_business_as, :string
+    add_column :organizations, :kyb_company_structure, :string
+    add_column :organizations, :kyb_company_registration_number, :string
+    add_column :organizations, :kyb_address_line1, :string
+    add_column :organizations, :kyb_address_city, :string
+    add_column :organizations, :kyb_address_state, :string
+    add_column :organizations, :kyb_address_zip, :string
+    add_column :organizations, :kyb_country_code, :string
+    add_column :organizations, :kyb_website_url, :string
+  end
+end

--- a/models/organization.rb
+++ b/models/organization.rb
@@ -1,3 +1,27 @@
 class Organization < ActiveRecord::Base
   validates :name, presence: true
+
+  # Assembles the optional `kyb` pass-through object sent to Tremendous on
+  # POST /connected_organizations. Only non-blank fields are included, so the
+  # object is fully optional — returns nil when no KYB data was provided, in
+  # which case the request omits `kyb` entirely and the end client fills in the
+  # onboarding form from scratch.
+  def prefilled_kyb_details
+    address = {
+      line1: kyb_address_line1,
+      city: kyb_address_city,
+      state: kyb_address_state,
+      zip: kyb_address_zip
+    }.compact_blank
+
+    {
+      company_name: kyb_company_name,
+      doing_business_as: kyb_doing_business_as,
+      company_structure: kyb_company_structure,
+      company_registration_number: kyb_company_registration_number,
+      country_code: kyb_country_code,
+      website_url: kyb_website_url,
+      address: address.presence
+    }.compact_blank.presence
+  end
 end

--- a/services/tremendous_api_service.rb
+++ b/services/tremendous_api_service.rb
@@ -5,12 +5,18 @@ class TremendousApiService
   include HTTParty
   base_uri ENV["TREMENDOUS_API_URL"]
 
-  def self.create_connected_organization
+  def self.create_connected_organization(kyb: nil)
+    body = { client_id: ENV["OAUTH_CLIENT_ID"] }
+    # Optional KYB pass-through: when the platform already collected KYB on its
+    # end client, forward it so the onboarding form is pre-filled. Omitted
+    # entirely when no KYB data is available.
+    body[:kyb] = kyb if kyb
+
     handle_response(
       post(
         "/connected_organizations",
         headers: headers,
-        body: { client_id: ENV["OAUTH_CLIENT_ID"] }.to_json
+        body: body.to_json
       )
     )
   end

--- a/views/organizations/new.erb
+++ b/views/organizations/new.erb
@@ -56,6 +56,103 @@
           </div>
         <% end %>
       </div>
+      <hr class="my-4">
+      <h5 class="mb-1">KYB pass-through <span class="text-muted fw-normal">(optional)</span></h5>
+      <p class="text-muted small mb-3">
+        If you already collected KYB info from this client, fill it in here. It's
+        sent to Tremendous as the <code>kyb</code> object on
+        <code>POST /connected_organizations</code> and pre-fills the end client's
+        onboarding form. Every field is optional and remains editable by the end client.
+      </p>
+
+      <div class="mb-3">
+        <label for="organization_kyb_company_name" class="form-label">Company Name</label>
+        <input type="text"
+               id="organization_kyb_company_name"
+               name="organization[kyb_company_name]"
+               class="form-control"
+               value="<%= @organization.kyb_company_name %>">
+      </div>
+      <div class="mb-3">
+        <label for="organization_kyb_doing_business_as" class="form-label">Doing Business As (DBA)</label>
+        <input type="text"
+               id="organization_kyb_doing_business_as"
+               name="organization[kyb_doing_business_as]"
+               class="form-control"
+               value="<%= @organization.kyb_doing_business_as %>">
+      </div>
+      <div class="mb-3">
+        <label for="organization_kyb_company_structure" class="form-label">Company Structure (entity type)</label>
+        <input type="text"
+               id="organization_kyb_company_structure"
+               name="organization[kyb_company_structure]"
+               class="form-control"
+               placeholder="e.g. llc, corporation, sole_proprietorship"
+               value="<%= @organization.kyb_company_structure %>">
+      </div>
+      <div class="mb-3">
+        <label for="organization_kyb_company_registration_number" class="form-label">Company Registration Number (Tax ID)</label>
+        <input type="text"
+               id="organization_kyb_company_registration_number"
+               name="organization[kyb_company_registration_number]"
+               class="form-control"
+               value="<%= @organization.kyb_company_registration_number %>">
+      </div>
+      <div class="mb-3">
+        <label for="organization_kyb_address_line1" class="form-label">Address Line 1</label>
+        <input type="text"
+               id="organization_kyb_address_line1"
+               name="organization[kyb_address_line1]"
+               class="form-control"
+               value="<%= @organization.kyb_address_line1 %>">
+      </div>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <label for="organization_kyb_address_city" class="form-label">City</label>
+          <input type="text"
+                 id="organization_kyb_address_city"
+                 name="organization[kyb_address_city]"
+                 class="form-control"
+                 value="<%= @organization.kyb_address_city %>">
+        </div>
+        <div class="col-md-3 mb-3">
+          <label for="organization_kyb_address_state" class="form-label">State</label>
+          <input type="text"
+                 id="organization_kyb_address_state"
+                 name="organization[kyb_address_state]"
+                 class="form-control"
+                 value="<%= @organization.kyb_address_state %>">
+        </div>
+        <div class="col-md-3 mb-3">
+          <label for="organization_kyb_address_zip" class="form-label">Zip</label>
+          <input type="text"
+                 id="organization_kyb_address_zip"
+                 name="organization[kyb_address_zip]"
+                 class="form-control"
+                 value="<%= @organization.kyb_address_zip %>">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4 mb-3">
+          <label for="organization_kyb_country_code" class="form-label">Country Code</label>
+          <input type="text"
+                 id="organization_kyb_country_code"
+                 name="organization[kyb_country_code]"
+                 class="form-control"
+                 placeholder="e.g. US"
+                 value="<%= @organization.kyb_country_code %>">
+        </div>
+        <div class="col-md-8 mb-3">
+          <label for="organization_kyb_website_url" class="form-label">Website URL</label>
+          <input type="url"
+                 id="organization_kyb_website_url"
+                 name="organization[kyb_website_url]"
+                 class="form-control"
+                 placeholder="https://example.com"
+                 value="<%= @organization.kyb_website_url %>">
+        </div>
+      </div>
+
       <button type="submit" class="btn btn-primary">Create</button>
       <a href="/organizations" class="btn btn-secondary">Cancel</a>
     </form>

--- a/views/organizations/show.erb
+++ b/views/organizations/show.erb
@@ -41,6 +41,17 @@
       </div>
     </div>
 
+    <% if @organization.prefilled_kyb_details %>
+      <div class="row mb-4">
+        <div class="col-12">
+          <h3 class="mb-3">KYB Pre-fill <span class="text-muted fs-6 fw-normal">(sent to Tremendous as the <code>kyb</code> object)</span></h3>
+          <div class="bg-light p-3 rounded">
+            <pre class="mb-0 overflow-auto" style="max-height: 400px;"><code><%= JSON.pretty_generate(@organization.prefilled_kyb_details) %></code></pre>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <div>
       <% if @organization.tremendous_connected_organization_member_id.blank? %>
         <form action="/organizations/<%= @organization.id %>/tremendous_setup" method="post" class="d-inline">


### PR DESCRIPTION
### Description

Adds a reference implementation of the optional KYB pass-through to the sample app. When a platform has already collected KYB info from its end client, those fields can now be forwarded to Tremendous as an optional `kyb` object on `POST /connected_organizations`, which pre-fills the end client's onboarding form (still fully reviewable and editable by them).

The "New Organization" form gains an optional KYB section, and the values are sent at "Set up on Tremendous" time via a `prefilled_kyb_details` helper that assembles the object and omits blank fields. The object is fully optional — when no KYB data is provided, `kyb` is omitted and the call is unchanged. Doubles as the end-to-end test harness for the feature once the platform side is deployed.

https://github.com/user-attachments/assets/437b5711-638c-4526-a00e-b26590be9789


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215456119519826