### PR TITLE
Update KYB pass-through to the kyb_prefill API shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ This section assumes that:
 
 If your platform already collects KYB (Know Your Business) information from your end
 clients, you can forward it to Tremendous so the end client doesn't have to re-type it.
-When provided, Tremendous pre-fills the onboarding form with this data; the end client
+When provided, Tremendous prefills the onboarding form with this data; the end client
 still reviews every field, can edit anything, and submits the form as usual.
 
-To pass it through, include an optional `kyb` object in the body of the
+To pass it through, include an optional `kyb_prefill` object in the body of the
 [`POST /connected_organizations`](https://developers.tremendous.com/reference/create-connected-organization)
 call. This sample app collects these fields in the optional "KYB pass-through" section of
 the "New Organization" form and sends them when you click "Set up on Tremendous"
@@ -49,26 +49,24 @@ The supported fields are:
 ```jsonc
 {
   "client_id": "<your-oauth-client-id>",
-  "kyb": {
+  "kyb_prefill": {
     "company_name": "Acme Inc",
     "doing_business_as": "Acme",
-    "company_structure": "llc",
+    "company_structure": "Corporation (Inc)",
     "company_registration_number": "12-3456789",
     "country_code": "US",
     "website_url": "https://acme.example",
-    "address": {
-      "line1": "1 Main St",
-      "city": "Austin",
-      "state": "TX",
-      "zip": "78701"
-    }
+    "address_1": "1 Main St",
+    "city": "Austin",
+    "state": "TX",
+    "postal_code": "78701"
   }
 }
 ```
 
 Every field is optional. This sample app only includes the fields you actually fill in and
-omits the `kyb` object entirely when none are provided, so the call works unchanged when you
-have no KYB data to forward.
+omits the `kyb_prefill` object entirely when none are provided, so the call works unchanged
+when you have no KYB data to forward.
 
 ### Listening for webhooks
 

--- a/controllers/organizations_controller.rb
+++ b/controllers/organizations_controller.rb
@@ -40,10 +40,10 @@ class OrganizationsController < BaseController
     begin
       # Tremendous API call to create the connected organization, optionally
       # passing through any KYB info the platform already collected so the end
-      # client's onboarding form is pre-filled.
+      # client's onboarding form is prefilled.
       if @organization.tremendous_connected_organization_id.blank?
         response = TremendousApiService.create_connected_organization(
-          kyb: @organization.prefilled_kyb_details
+          kyb_prefill: @organization.kyb_prefill_details
         )
 
         payload = response.fetch("connected_organization")

--- a/models/organization.rb
+++ b/models/organization.rb
@@ -1,19 +1,12 @@
 class Organization < ActiveRecord::Base
   validates :name, presence: true
 
-  # Assembles the optional `kyb` pass-through object sent to Tremendous on
-  # POST /connected_organizations. Only non-blank fields are included, so the
+  # Assembles the optional `kyb_prefill` pass-through object sent to Tremendous
+  # on POST /connected_organizations. Only non-blank fields are included, so the
   # object is fully optional — returns nil when no KYB data was provided, in
-  # which case the request omits `kyb` entirely and the end client fills in the
-  # onboarding form from scratch.
-  def prefilled_kyb_details
-    address = {
-      line1: kyb_address_line1,
-      city: kyb_address_city,
-      state: kyb_address_state,
-      zip: kyb_address_zip
-    }.compact_blank
-
+  # which case the request omits `kyb_prefill` entirely and the end client fills
+  # in the onboarding form from scratch.
+  def kyb_prefill_details
     {
       company_name: kyb_company_name,
       doing_business_as: kyb_doing_business_as,
@@ -21,7 +14,10 @@ class Organization < ActiveRecord::Base
       company_registration_number: kyb_company_registration_number,
       country_code: kyb_country_code,
       website_url: kyb_website_url,
-      address: address.presence
+      address_1: kyb_address_line1,
+      city: kyb_address_city,
+      state: kyb_address_state,
+      postal_code: kyb_address_zip
     }.compact_blank.presence
   end
 end

--- a/services/tremendous_api_service.rb
+++ b/services/tremendous_api_service.rb
@@ -5,12 +5,12 @@ class TremendousApiService
   include HTTParty
   base_uri ENV["TREMENDOUS_API_URL"]
 
-  def self.create_connected_organization(kyb: nil)
+  def self.create_connected_organization(kyb_prefill: nil)
     body = { client_id: ENV["OAUTH_CLIENT_ID"] }
     # Optional KYB pass-through: when the platform already collected KYB on its
-    # end client, forward it so the onboarding form is pre-filled. Omitted
+    # end client, forward it so the onboarding form is prefilled. Omitted
     # entirely when no KYB data is available.
-    body[:kyb] = kyb if kyb
+    body[:kyb_prefill] = kyb_prefill if kyb_prefill
 
     handle_response(
       post(

--- a/views/organizations/new.erb
+++ b/views/organizations/new.erb
@@ -60,8 +60,8 @@
       <h5 class="mb-1">KYB pass-through <span class="text-muted fw-normal">(optional)</span></h5>
       <p class="text-muted small mb-3">
         If you already collected KYB info from this client, fill it in here. It's
-        sent to Tremendous as the <code>kyb</code> object on
-        <code>POST /connected_organizations</code> and pre-fills the end client's
+        sent to Tremendous as the <code>kyb_prefill</code> object on
+        <code>POST /connected_organizations</code> and prefills the end client's
         onboarding form. Every field is optional and remains editable by the end client.
       </p>
 
@@ -87,7 +87,7 @@
                id="organization_kyb_company_structure"
                name="organization[kyb_company_structure]"
                class="form-control"
-               placeholder="e.g. llc, corporation, sole_proprietorship"
+               placeholder="e.g. Corporation (Inc), Limited liability company (LLC), Sole proprietorship"
                value="<%= @organization.kyb_company_structure %>">
       </div>
       <div class="mb-3">

--- a/views/organizations/show.erb
+++ b/views/organizations/show.erb
@@ -41,12 +41,12 @@
       </div>
     </div>
 
-    <% if @organization.prefilled_kyb_details %>
+    <% if @organization.kyb_prefill_details %>
       <div class="row mb-4">
         <div class="col-12">
-          <h3 class="mb-3">KYB Pre-fill <span class="text-muted fs-6 fw-normal">(sent to Tremendous as the <code>kyb</code> object)</span></h3>
+          <h3 class="mb-3">KYB Prefill <span class="text-muted fs-6 fw-normal">(sent to Tremendous as the <code>kyb_prefill</code> object)</span></h3>
           <div class="bg-light p-3 rounded">
-            <pre class="mb-0 overflow-auto" style="max-height: 400px;"><code><%= JSON.pretty_generate(@organization.prefilled_kyb_details) %></code></pre>
+            <pre class="mb-0 overflow-auto" style="max-height: 400px;"><code><%= JSON.pretty_generate(@organization.kyb_prefill_details) %></code></pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Asana Ticket

Asana ticket: https://app.asana.com/1/752389237742425/project/1201167105706402/task/1213480670738455

Backend PR: https://github.com/tremendous-rewards/tremendous/pull/96

### Description

Mirrors the pre-launch public API cleanup applied to the (not-yet-released) KYB pass-through feature in the backend, so the sample app demonstrates the final shape integrators should send:

- Rename the request key `kyb` → `kyb_prefill`.
- Flatten and rename the address fields to match the rest of the public API (invoice billing): `address_1` / `city` / `state` / `postal_code`, instead of a nested `address` object with `line1` / `zip`.

https://github.com/user-attachments/assets/b114c66e-a4e8-4a82-a3c3-3aeeb5948d51

Gated: do not merge until backend PR #96 is live, since this repo is public.