### PR TITLE
Add currency code to organization creation form

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Every field is optional. This sample app only includes the fields you actually f
 omits the `kyb_prefill` object entirely when none are provided, so the call works unchanged
 when you have no KYB data to forward.
 
+### Selecting a connected organization currency (optional)
+
+The "New Organization" form includes a currency selector for exercising the optional
+`currency_code` field on `POST /connected_organizations`. Selecting `<empty>` omits the
+field and exercises the API's USD default. USD, GBP, and EUR are supported explicit
+choices. CAD is included intentionally to demonstrate the API's validation-error response;
+the connected organization and member IDs remain unset when that request is rejected.
+
 ### Listening for webhooks
 
 This sample app shows how to listen for webhooks from Tremendous. These are handled by the [WebhooksController](https://github.com/tremendous-rewards/tremendous-for-platforms-sample-app/blob/main/controllers/webhooks_controller.rb) and are expected to be received in the `/webhooks` path.

--- a/controllers/organizations_controller.rb
+++ b/controllers/organizations_controller.rb
@@ -43,7 +43,8 @@ class OrganizationsController < BaseController
       # client's onboarding form is prefilled.
       if @organization.tremendous_connected_organization_id.blank?
         response = TremendousApiService.create_connected_organization(
-          kyb_prefill: @organization.kyb_prefill_details
+          kyb_prefill: @organization.kyb_prefill_details,
+          currency_code: @organization.currency_code
         )
 
         payload = response.fetch("connected_organization")

--- a/db/migrate/20260720000000_add_currency_code_to_organizations.rb
+++ b/db/migrate/20260720000000_add_currency_code_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddCurrencyCodeToOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organizations, :currency_code, :string
+  end
+end

--- a/models/organization.rb
+++ b/models/organization.rb
@@ -1,5 +1,8 @@
 class Organization < ActiveRecord::Base
+  CURRENCY_CODES = %w[USD GBP EUR CAD].freeze
+
   validates :name, presence: true
+  validates :currency_code, inclusion: { in: CURRENCY_CODES }, allow_blank: true
 
   # Assembles the optional `kyb_prefill` pass-through object sent to Tremendous
   # on POST /connected_organizations. Only non-blank fields are included, so the

--- a/models/organization.rb
+++ b/models/organization.rb
@@ -1,5 +1,9 @@
 class Organization < ActiveRecord::Base
+  # CAD is intentionally included for testing the API's validation-error path;
+  # Tremendous only supports USD, GBP, and EUR as explicit currency codes.
   CURRENCY_CODES = %w[USD GBP EUR CAD].freeze
+
+  normalizes :currency_code, with: ->(code) { code.presence }
 
   validates :name, presence: true
   validates :currency_code, inclusion: { in: CURRENCY_CODES }, allow_blank: true

--- a/services/tremendous_api_service.rb
+++ b/services/tremendous_api_service.rb
@@ -5,12 +5,13 @@ class TremendousApiService
   include HTTParty
   base_uri ENV["TREMENDOUS_API_URL"]
 
-  def self.create_connected_organization(kyb_prefill: nil)
+  def self.create_connected_organization(kyb_prefill: nil, currency_code: nil)
     body = { client_id: ENV["OAUTH_CLIENT_ID"] }
     # Optional KYB pass-through: when the platform already collected KYB on its
     # end client, forward it so the onboarding form is prefilled. Omitted
     # entirely when no KYB data is available.
     body[:kyb_prefill] = kyb_prefill if kyb_prefill
+    body[:currency_code] = currency_code unless currency_code.to_s.empty?
 
     handle_response(
       post(

--- a/services/tremendous_api_service.rb
+++ b/services/tremendous_api_service.rb
@@ -11,7 +11,7 @@ class TremendousApiService
     # end client, forward it so the onboarding form is prefilled. Omitted
     # entirely when no KYB data is available.
     body[:kyb_prefill] = kyb_prefill if kyb_prefill
-    body[:currency_code] = currency_code unless currency_code.to_s.empty?
+    body[:currency_code] = currency_code if currency_code.present?
 
     handle_response(
       post(

--- a/views/organizations/new.erb
+++ b/views/organizations/new.erb
@@ -152,6 +152,14 @@
                  value="<%= @organization.kyb_website_url %>">
         </div>
       </div>
+
+      <hr class="my-4">
+      <h5 class="mb-1">Connected organization currency <span class="text-muted fw-normal">(optional)</span></h5>
+      <p class="text-muted small mb-3">
+        Sent to Tremendous as the standalone <code>currency_code</code> field,
+        separate from the <code>kyb_prefill</code> object.
+      </p>
+
       <div class="mb-3">
         <label for="organization_currency_code" class="form-label">Currency code</label>
         <select id="organization_currency_code"
@@ -169,6 +177,8 @@
         <% end %>
         <div class="form-text">
           &lt;empty&gt; omits <code>currency_code</code> from the API request and exercises the USD default.
+          <br>
+          CAD is included for testing and is expected to fail during Tremendous setup because the API does not support it.
         </div>
       </div>
 

--- a/views/organizations/new.erb
+++ b/views/organizations/new.erb
@@ -152,6 +152,25 @@
                  value="<%= @organization.kyb_website_url %>">
         </div>
       </div>
+      <div class="mb-3">
+        <label for="organization_currency_code" class="form-label">Currency code</label>
+        <select id="organization_currency_code"
+                name="organization[currency_code]"
+                class="form-select <%= 'is-invalid' if @organization.errors[:currency_code].any? %>">
+          <option value="" <%= 'selected' if @organization.currency_code.blank? %>>&lt;empty&gt;</option>
+          <% Organization::CURRENCY_CODES.each do |currency_code| %>
+            <option value="<%= currency_code %>" <%= 'selected' if @organization.currency_code == currency_code %>><%= currency_code %></option>
+          <% end %>
+        </select>
+        <% if @organization.errors[:currency_code].any? %>
+          <div class="invalid-feedback">
+            <%= @organization.errors[:currency_code].join(', ') %>
+          </div>
+        <% end %>
+        <div class="form-text">
+          &lt;empty&gt; omits <code>currency_code</code> from the API request and exercises the USD default.
+        </div>
+      </div>
 
       <button type="submit" class="btn btn-primary">Create</button>
       <a href="/organizations" class="btn btn-secondary">Cancel</a>

--- a/views/organizations/show.erb
+++ b/views/organizations/show.erb
@@ -12,6 +12,15 @@
           <dt class="col-sm-4">Creator Email</dt>
           <dd class="col-sm-8"><%= @organization.creator_email %></dd>
 
+          <dt class="col-sm-4">Currency Code</dt>
+          <dd class="col-sm-8">
+            <% if @organization.currency_code.present? %>
+              <%= @organization.currency_code %>
+            <% else %>
+              &lt;empty&gt; (<code>currency_code</code> omitted; defaults to USD)
+            <% end %>
+          </dd>
+
           <dt class="col-sm-4">Created At</dt>
           <dd class="col-sm-8"><%= @organization.created_at&.strftime('%B %d, %Y %H:%M') %></dd>
         </dl>


### PR DESCRIPTION
Add a new (optional) field for the currency. If none is giving, the USD default is used. Even though CAD is not supported by the backend, it is added here as a way of testing what happens when an invalid currency code is passed to the API.

<img width="1280" height="1600" alt="tremendous-connect-currency-dropdown" src="https://github.com/user-attachments/assets/0210a668-3d3e-4d6f-b474-f986d45eeb71" />
