### PR TITLE
Add currency_code to README.md request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The supported fields are:
 ```jsonc
 {
   "client_id": "<your-oauth-client-id>",
+  "currency_code": "USD",
   "kyb_prefill": {
     "company_name": "Acme Inc",
     "doing_business_as": "Acme",


### PR DESCRIPTION
### Asana Ticket and/or Slack Thread

Asana ticket: https://app.asana.com/1/752389237742425/project/1200740969880463/task/1216659903635466?focus=true
Notion brief: https://www.notion.so/tremendous/Support-Tremendous-Connect-for-non-USD-orgs-350eed2e006880e9a925c92ec134e3f8?source=copy_link

### Description

The sample app now demonstrates choosing a balance currency when creating a connected organization, but the README request example omitted that field. This keeps the onboarding documentation aligned with the sample flow and makes clear that `currency_code` belongs at the request’s top level alongside `client_id` and `kyb_prefill`.

The following currency section continues to document that the field is optional and defaults to USD when omitted.