### PR TITLE
Add address line 2 to the KYB pre-fill form and request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The supported fields are:
     "country_code": "US",
     "website_url": "https://acme.example",
     "address_1": "1 Main St",
+    "address_2": "Suite 100",
     "city": "Austin",
     "state": "TX",
     "postal_code": "78701"

--- a/db/migrate/20260804000000_add_kyb_address_line2_to_organizations.rb
+++ b/db/migrate/20260804000000_add_kyb_address_line2_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddKybAddressLine2ToOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organizations, :kyb_address_line2, :string
+  end
+end

--- a/models/organization.rb
+++ b/models/organization.rb
@@ -22,6 +22,7 @@ class Organization < ActiveRecord::Base
       country_code: kyb_country_code,
       website_url: kyb_website_url,
       address_1: kyb_address_line1,
+      address_2: kyb_address_line2,
       city: kyb_address_city,
       state: kyb_address_state,
       postal_code: kyb_address_zip

--- a/views/organizations/new.erb
+++ b/views/organizations/new.erb
@@ -106,6 +106,14 @@
                class="form-control"
                value="<%= @organization.kyb_address_line1 %>">
       </div>
+      <div class="mb-3">
+        <label for="organization_kyb_address_line2" class="form-label">Address Line 2</label>
+        <input type="text"
+               id="organization_kyb_address_line2"
+               name="organization[kyb_address_line2]"
+               class="form-control"
+               value="<%= @organization.kyb_address_line2 %>">
+      </div>
       <div class="row">
         <div class="col-md-6 mb-3">
           <label for="organization_kyb_address_city" class="form-label">City</label>


### PR DESCRIPTION
### Description

The Connect API is gaining an optional `address_2` field in the `kyb_prefill` object on `POST /connected_organizations` (item 12 of the linked ticket; main-repo changes are in tremendous-rewards/tremendous#2113). This updates the sample app to match: an optional "Address Line 2" input on the New Organization form and the `address_2` field in the README request example.

Like the other KYB fields, a blank line 2 is omitted from the request payload entirely.


https://github.com/user-attachments/assets/eba28a38-59b2-4ff2-a93e-629cf5de126b



